### PR TITLE
Add a `Sized` bound to the `Comonoid` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 /// implementation of [`Drop`](http://doc.rust-lang.org/std/ops/trait.Drop.html)
 /// and [`Clone`](http://doc.rust-lang.org/std/clone/trait.Clone.html),
 /// respectively.
-pub trait Comonoid {
+pub trait Comonoid: Sized {
     /// The dual to the monoidal unit.
     fn counit(self) -> ();
     /// The dual to the monoidal multiplication.


### PR DESCRIPTION
Otherwise the type `(Self, Self)` is not well-formed, as tuples may not
have unsized members. See rust-lang/rust#33242 for details.
